### PR TITLE
Fix Python 3.14+ compatibility issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         - ghcr.io/robotpy/crossenv-ci-images:py311-arm64-24.04-qemu
         - ghcr.io/robotpy/crossenv-ci-images:py312-arm64-24.04-qemu
         - ghcr.io/robotpy/crossenv-ci-images:py313-arm64-24.04-qemu
+        - ghcr.io/robotpy/crossenv-ci-images:py314-arm64-24.04-qemu
 
     container:
       image: "${{ matrix.container }}"

--- a/crossenv/scripts/os-patch.py.tmpl
+++ b/crossenv/scripts/os-patch.py.tmpl
@@ -1,15 +1,14 @@
-from collections import namedtuple
+import posix
 
 # Fixup os.uname, which should fix most of platform module
-uname_result_type = namedtuple(
-    "uname_result", "sysname nodename release version machine"
-)
-_uname_result = uname_result_type(
-    {{repr(self.host_sysname)}},
-    "build",
-    {{repr(self.host_release)}},
-    "",
-    {{repr(self.host_machine)}},
+_uname_result = posix.uname_result(
+    (
+        {{repr(self.host_sysname)}},
+        "build",
+        {{repr(self.host_release)}},
+        "",
+        {{repr(self.host_machine)}},
+    )
 )
 
 

--- a/crossenv/scripts/site.py.tmpl
+++ b/crossenv/scripts/site.py.tmpl
@@ -59,7 +59,8 @@ def _patch_module(module, patch):
     # The default causes an import to happen too early.
     with open(patch, "r", encoding="utf-8") as fp:
         src = fp.read()
-    exec(src, module.__dict__, module.__dict__)
+    code = compile(src, patch, "exec")
+    exec(code, module.__dict__, module.__dict__)
     module.__patched__ = True
 
 

--- a/crossenv/scripts/sysconfig-patch.py.tmpl
+++ b/crossenv/scripts/sysconfig-patch.py.tmpl
@@ -3,7 +3,10 @@
 _PROJECT_BASE = {{repr(self.host_project_base)}}
 
 # Things that need to be re-evaluated after patching
-_PYTHON_BUILD = is_python_build(True)
+if sys.version_info[:2] < (3, 12):
+    _PYTHON_BUILD = is_python_build(True)
+else:
+    _PYTHON_BUILD = is_python_build()
 _PREFIX = os.path.normpath(sys.prefix)
 _BASE_PREFIX = os.path.normpath(sys.base_prefix)
 _EXEC_PREFIX = os.path.normpath(sys.exec_prefix)


### PR DESCRIPTION
This PR addresses several compatibility issues that arise when using crossenv with Python 3.14+, fixing import loops and deprecation warnings.

### Make tracebacks involving _patch_module more readable by including file path
- Improves debugging experience by showing actual file paths in tracebacks

### Use posix.uname_result rather than making a named tuple
- Fixes import loop in Python 3.14 caused by crossenv's patching conflicting with `collections.namedtuple` import

<details>
<summary>Python 3.14 traceback (click to expand)</summary>

```
Fatal Python error: init_import_site: Failed to import the site module
Python runtime state: initialized
Traceback (most recent call last):
  File "/.../build_env/venv/lib/site.py", line 177, in <module>
  File "/.../build_env/venv/lib/site.py", line 122, in __init__
  File "/.../build_env/venv/lib/site.py", line 170, in manually_patch_loaded
  File "/.../build_env/venv/lib/site.py", line 56, in _patch_module
  File "/.../build_env/venv/lib/os-patch.py", line 1, in <module>
  File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1333, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1267, in _find_spec
  File "/.../build_env/venv/lib/importlib-machinery-patch.py", line 18, in _PathFinder_find_spec
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 507, in get_path
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 497, in get_paths
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 276, in _expand_vars
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 625, in get_config_vars
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 525, in _init_config_vars
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 393, in _init_posix
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 373, in _get_sysconfigdata
  File "/.../build_env/lib/python3.14/importlib/__init__.py", line 88, in import_module
  File "<frozen importlib._bootstrap>", line 1398, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1333, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1267, in _find_spec
  File "/.../build_env/venv/lib/importlib-machinery-patch.py", line 18, in _PathFinder_find_spec
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 507, in get_path
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 497, in get_paths
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 286, in _expand_vars
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 262, in _subst_vars
AttributeError: 'installed_base'
```
</details>

### Don't pass any argument to `is_python_build` due to deprecation since Python 3.12
- The argument was [deprecated in Python 3.12](https://github.com/python/cpython/commit/067597522a9002f3b8aff7f46033f10acb2381e4#diff-d593bd299ba58e440ba411ffa0640ccd9d20d518b0cf2644ed4bdb75a82a3e70) and will be removed in Python 3.15
- Fixes another import loop in Python 3.14 (this time with `warnings`)

<details>
<summary>Python 3.14 traceback (click to expand)</summary>

```
Fatal Python error: init_import_site: Failed to import the site module
Python runtime state: initialized
Traceback (most recent call last):
  File "/.../build_env/venv/lib/site.py", line 177, in <module>
  File "/.../build_env/venv/lib/site.py", line 122, in __init__
  File "/.../build_env/venv/lib/site.py", line 170, in manually_patch_loaded
  File "/.../build_env/venv/lib/site.py", line 56, in _patch_module
  File "/.../build_env/venv/lib/sysconfig-patch.py", line 5, in <module>
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 225, in is_python_build
  File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1333, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1267, in _find_spec
  File "/.../build_env/venv/lib/importlib-machinery-patch.py", line 18, in _PathFinder_find_spec
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 507, in get_path
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 497, in get_paths
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 276, in _expand_vars
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 625, in get_config_vars
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 525, in _init_config_vars
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 393, in _init_posix
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 373, in _get_sysconfigdata
  File "/.../build_env/lib/python3.14/importlib/__init__.py", line 88, in import_module
  File "<frozen importlib._bootstrap>", line 1398, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1333, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1267, in _find_spec
  File "/.../build_env/venv/lib/importlib-machinery-patch.py", line 18, in _PathFinder_find_spec
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 507, in get_path
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 497, in get_paths
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 286, in _expand_vars
  File "/.../build_env/lib/python3.14/sysconfig/__init__.py", line 262, in _subst_vars
AttributeError: 'installed_base'
```
</details>
